### PR TITLE
feat: add EditorConfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.lua]
+max_line_length = 80
+end_of_line = lf
+indent_style = "space"
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The settings table (`opts`) may define the following fields.
 | **use_default_set**  | `bool`                                        | Whether to use the `default` set when no `filetype` set is found, defaults to true.                            |
 | **exclude_floating** | `bool`                                        | Whether the plugin should be disabled in floating windows, such as mason.nvim and lazy.nvim.                   |
 | **exclude_ft**       | `string[]`                                    | List of filetypes (strings) the plugin should be disabled under.                                               |
+| **editorconfig**     | `bool`                                        | Whether to use the max_line_length value from .editorconfig                                                    |
 | **base_set**         | `table`: set, see below                       | Base set all other sets inherit from when options are missing.                                                 |
 | **sets**             | `table[]`: set list, see below                | Defines plugin behavior for each defined `filetype` set. Accepts a `default` set for fallback behavior.        |
 
@@ -124,6 +125,7 @@ max_size = 64 * 1024 * 1024, -- 0 (disabled) OR int
 use_default_set = true,
 exclude_floating = true,
 exclude_ft = { 'markdown', 'help', 'netrw' },
+editorconfig = false,
 base_set = {
   scope = 'window', -- file, window, line
   rulers = {}, -- { int, int, ... }

--- a/lua/multicolumn/column.lua
+++ b/lua/multicolumn/column.lua
@@ -47,7 +47,7 @@ local function colorcolumn_editorconfig(rulers)
 
   if editorconfig_max_line_length == 'null' then return rulers end
 
-  return { tonumber(editorconfig_max_line_length) }
+  return { tonumber(editorconfig_max_line_length) + 1 }
 end
 
 local function get_exceeded(ruleset, buf, win)

--- a/lua/multicolumn/column.lua
+++ b/lua/multicolumn/column.lua
@@ -40,14 +40,14 @@ end
 
 -- Inspired by work of loicreynier in smartcolumn.nvim PR and the main smartcolumn.nvim
 local function colorcolumn_editorconfig(rulers)
-  local editorconfig_max_line_length = vim.b[0].editorconfig
-      and vim.b[0].editorconfig.max_line_length ~= 'off'
-      and vim.b[0].editorconfig.max_line_length
-    or 'null'
-
-  if editorconfig_max_line_length == 'null' then return rulers end
-
-  return { tonumber(editorconfig_max_line_length) + 1 }
+  local max_line_length = vim.b.editorconfig
+      and vim.b.editorconfig.max_line_length ~= 'off'
+      and vim.b.editorconfig.max_line_length ~= 'unset'
+      and vim.b.editorconfig.max_line_length
+    
+  if max_line_length then
+    return { tonumber(max_line_length) + 1 }
+  end
 end
 
 local function get_exceeded(ruleset, buf, win)
@@ -160,7 +160,7 @@ function M.update(win)
   end
 
   if config.opts.editorconfig then
-    ruleset.rulers = colorcolumn_editorconfig(ruleset.rulers)
+    ruleset.rulers = colorcolumn_editorconfig() or ruleset.rulers
   end
 
   if ruleset.full_column or ruleset.always_on then

--- a/lua/multicolumn/column.lua
+++ b/lua/multicolumn/column.lua
@@ -38,6 +38,18 @@ local function is_disabled(win)
   return false
 end
 
+-- Inspired by work of loicreynier in smartcolumn.nvim PR and the main smartcolumn.nvim
+local function colorcolumn_editorconfig(rulers)
+  local editorconfig_max_line_length = vim.b[0].editorconfig
+      and vim.b[0].editorconfig.max_line_length ~= 'off'
+      and vim.b[0].editorconfig.max_line_length
+    or 'null'
+
+  if editorconfig_max_line_length == 'null' then return rulers end
+
+  return { tonumber(editorconfig_max_line_length) }
+end
+
 local function get_exceeded(ruleset, buf, win)
   local lines = nil
 
@@ -145,6 +157,10 @@ function M.update(win)
       bg = ruleset.bg_color or config.default_bg_color or '',
       fg = ruleset.fg_color or config.default_fg_color or '',
     })
+  end
+
+  if config.opts.editorconfig then
+    ruleset.rulers = colorcolumn_editorconfig(ruleset.rulers)
   end
 
   if ruleset.full_column or ruleset.always_on then

--- a/lua/multicolumn/config.lua
+++ b/lua/multicolumn/config.lua
@@ -9,6 +9,7 @@ local defaults = {
   use_default_set = true,
   exclude_floating = true,
   exclude_ft = { 'markdown', 'help', 'netrw' },
+  editorconfig = false,
   base_set = {
     scope = 'window', -- file, window, line
     rulers = {}, -- { int, int, ... }


### PR DESCRIPTION
Hey, I'm new here; I hope you are doing well; thank you for creating this plugin; I appreciate the additional options it gives compared to what came before
I found your plugin and wanted to add support for recognizing the max_line_length variable in a .editorconfig file (to that point, I also added one to the project based on the Stylua file you provided; feel free to edit or remove it if it is inaccurate or intrusive)
My work was based on the work of user [loicreynier](https://github.com/loicreynier) in this [pull request](https://github.com/m4xshen/smartcolumn.nvim/pull/29) for the smartcolumn plugin that this plugin was inspired by. I also got the idea to use tonumber to convert the value from a string if needed from the [code for the main smartcolumn plugin. (lines 55-62 in particular)](https://github.com/m4xshen/smartcolumn.nvim/blob/main/lua/smartcolumn.lua).
Let me know if you have any suggestions or criticisms; otherwise, I hope you and any other users enjoy the new feature